### PR TITLE
more clear handling lifecycle: do not emmit data when activity hided.

### DIFF
--- a/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
@@ -11,7 +11,7 @@ import rx.Observable;
  * <p>
  * Contract of this interface:
  * <p>
- * 1) Each new subscription with loadAsync method should return the same result instantly
+ * 1) Each new subscription with load method should return the same result instantly
  * 2) #1 must be carried out event after configuration changes
  * 3) When Activity stopped request should be also stopped and restarted after activity is again visible
  * <p>
@@ -33,12 +33,12 @@ public interface LifecycleHandler {
      * @param id - unique identifier for request on Activity / Fragment
      */
     @NonNull
-    <T> Observable.Transformer<T, T> loadAsync(int id);
+    <T> Observable.Transformer<T, T> load(int id);
 
     /**
      * Use {@link Observable#compose(Observable.Transformer)} with with method
      * <p>
-     * This method provides almost the same functionality as {@link LifecycleHandler#loadAsync(int)}
+     * This method provides almost the same functionality as {@link LifecycleHandler#load(int)}
      * except it destroys previous request with the specified id and creates the new one
      * <p>
      * So the behaviour of this method is just the same as
@@ -47,7 +47,7 @@ public interface LifecycleHandler {
      * @param id - unique identifier for request on Activity / Fragment
      */
     @NonNull
-    <T> Observable.Transformer<T, T> reloadAsync(int id);
+    <T> Observable.Transformer<T, T> reloadA(int id);
 
     /**
      * This method clears subscriptions and destroys observable for the request with specified id

--- a/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
@@ -8,13 +8,13 @@ import rx.Observable;
 
 /**
  * Interface for handling configuration changes and activity stopping
- * <p/>
+ * <p>
  * Contract of this interface:
- * <p/>
- * 1) Each new subscription with load method should return the same result instantly
+ * <p>
+ * 1) Each new subscription with loadAsync method should return the same result instantly
  * 2) #1 must be carried out event after configuration changes
  * 3) When Activity stopped request should be also stopped and restarted after activity is again visible
- * <p/>
+ * <p>
  * The only known implementation is {@link LoaderLifecycleHandler} which is base on loaders
  *
  * @author Artur Vasilov
@@ -24,30 +24,30 @@ public interface LifecycleHandler {
     /**
      * Use {@link Observable#compose(Observable.Transformer)} with with method
      * That's nothing more that you'll do for most typical cases like loading single list of items
-     * <p/>
+     * <p>
      * You can call this method as many times as you like, for the same id it'll return the same result
-     * <p/>
+     * <p>
      * So the behaviour of this method is just the same as
      * {@link android.support.v4.app.LoaderManager#initLoader(int, Bundle, LoaderManager.LoaderCallbacks)}
      *
      * @param id - unique identifier for request on Activity / Fragment
      */
     @NonNull
-    <T> Observable.Transformer<T, T> load(int id);
+    <T> Observable.Transformer<T, T> loadAsync(int id);
 
     /**
      * Use {@link Observable#compose(Observable.Transformer)} with with method
-     * <p/>
-     * This method provides almost the same functionality as {@link LifecycleHandler#load(int)}
+     * <p>
+     * This method provides almost the same functionality as {@link LifecycleHandler#loadAsync(int)}
      * except it destroys previous request with the specified id and creates the new one
-     * <p/>
+     * <p>
      * So the behaviour of this method is just the same as
      * {@link android.support.v4.app.LoaderManager#restartLoader(int, Bundle, LoaderManager.LoaderCallbacks)}
      *
      * @param id - unique identifier for request on Activity / Fragment
      */
     @NonNull
-    <T> Observable.Transformer<T, T> reload(int id);
+    <T> Observable.Transformer<T, T> reloadAsync(int id);
 
     /**
      * This method clears subscriptions and destroys observable for the request with specified id

--- a/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/LifecycleHandler.java
@@ -47,7 +47,7 @@ public interface LifecycleHandler {
      * @param id - unique identifier for request on Activity / Fragment
      */
     @NonNull
-    <T> Observable.Transformer<T, T> reloadA(int id);
+    <T> Observable.Transformer<T, T> reload(int id);
 
     /**
      * This method clears subscriptions and destroys observable for the request with specified id

--- a/app/src/main/java/ru/arturvasilov/rxloader/LoaderLifecycleHandler.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/LoaderLifecycleHandler.java
@@ -52,7 +52,7 @@ public class LoaderLifecycleHandler implements LifecycleHandler {
 
     @NonNull
     @Override
-    public <T> Observable.Transformer<T, T> reloadA(@IdRes final int loaderId) {
+    public <T> Observable.Transformer<T, T> reload(@IdRes final int loaderId) {
         return new Observable.Transformer<T, T>() {
             @Override
             public Observable<T> call(final Observable<T> observable) {

--- a/app/src/main/java/ru/arturvasilov/rxloader/RxUtil.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/RxUtil.java
@@ -10,9 +10,9 @@ import rx.schedulers.Schedulers;
 /**
  * @author Artur Vasilov
  */
-public final class RxSchedulers {
+public final class RxUtil {
 
-    private RxSchedulers() {
+    private RxUtil() {
     }
 
     @NonNull
@@ -39,6 +39,5 @@ public final class RxSchedulers {
             }
         };
     }
-
 
 }

--- a/app/src/main/java/ru/arturvasilov/rxloader/RxUtils.java
+++ b/app/src/main/java/ru/arturvasilov/rxloader/RxUtils.java
@@ -10,9 +10,9 @@ import rx.schedulers.Schedulers;
 /**
  * @author Artur Vasilov
  */
-public final class RxUtil {
+public final class RxUtils {
 
-    private RxUtil() {
+    private RxUtils() {
     }
 
     @NonNull

--- a/app/src/test/java/ru/arturvasilov/rxloader/RxLoaderTest.java
+++ b/app/src/test/java/ru/arturvasilov/rxloader/RxLoaderTest.java
@@ -36,8 +36,8 @@ public class RxLoaderTest {
     public void testObservableNotExecuted() throws Exception {
         TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxUtil.<Integer>async(Schedulers.io(), Schedulers.io()))
-                .compose(mLifecycleHandler.<Integer>loadAsync(1));
+                .compose(RxUtils.<Integer>async(Schedulers.io(), Schedulers.io()))
+                .compose(mLifecycleHandler.<Integer>load(1));
 
         subscriber.assertNoValues();
     }

--- a/app/src/test/java/ru/arturvasilov/rxloader/RxLoaderTest.java
+++ b/app/src/test/java/ru/arturvasilov/rxloader/RxLoaderTest.java
@@ -36,8 +36,8 @@ public class RxLoaderTest {
     public void testObservableNotExecuted() throws Exception {
         TestSubscriber<Integer> subscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxSchedulers.<Integer>async(Schedulers.io(), Schedulers.io()))
-                .compose(mLifecycleHandler.<Integer>load(1));
+                .compose(RxUtil.<Integer>async(Schedulers.io(), Schedulers.io()))
+                .compose(mLifecycleHandler.<Integer>loadAsync(1));
 
         subscriber.assertNoValues();
     }


### PR DESCRIPTION
methods load and reload made async by default because the main purpose of loader is load data async with handling activity lifecycle.
small error emitting fix
